### PR TITLE
Don't disable filter selection if an API key is given

### DIFF
--- a/DerpibooruDownloaderGui/mainwindow.cpp
+++ b/DerpibooruDownloaderGui/mainwindow.cpp
@@ -335,10 +335,6 @@ void MainWindow::setHasAPIKey(bool hasKey)
 	ui->apiKey->setDisabled(hasKey);
 	ui->enterAPIKeyButton->setDisabled(hasKey);
 	
-	//Disable filter selection if an api key is given.
-	//As of Feb 13, 2017, The site will *always* use your selected filter on the site, and ignore the custom one sent with the search query.
-	ui->filterFrame->setEnabled(!hasKey);
-	
 	//Set text to show if a key is given
 	if(hasKey)
 	{

--- a/DerpibooruDownloaderGui/mainwindow.ui
+++ b/DerpibooruDownloaderGui/mainwindow.ui
@@ -197,7 +197,7 @@
                     <item row="1" column="0">
                      <widget class="QComboBox" name="filter">
                       <property name="toolTip">
-                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which standard filter should be used.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note: Filter options are disabled if you provide an api key, as the site will force the filter you have selected on your account over the one provided here. If you wish to use a different filter, you will need to log onto the site and change it there before downloading.&lt;/span&gt; (As of Feb 13, 2017)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which standard filter should be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                       <property name="currentIndex">
                        <number>0</number>


### PR DESCRIPTION
Using an API key no longer prevents using a different filter for searches.